### PR TITLE
feat: Disable proceed button for unavailable rooms

### DIFF
--- a/tourism_app_new/lib/widgets/check_availability_card.dart
+++ b/tourism_app_new/lib/widgets/check_availability_card.dart
@@ -579,8 +579,8 @@ class _EnhancedCheckAvailabilityCardState
               ),
             ),
 
-            // Proceed button when available
-            if (hasAvailability) ...[
+            // Proceed button
+            if (availabilityMessage != null)
               Container(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 15,
@@ -589,9 +589,9 @@ class _EnhancedCheckAvailabilityCardState
                 child: SizedBox(
                   width: double.infinity,
                   child: ElevatedButton(
-                    onPressed: _proceedWithBooking,
+                    onPressed: hasAvailability ? _proceedWithBooking : null,
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.green,
+                      backgroundColor: hasAvailability ? Colors.green : Colors.grey,
                       padding: const EdgeInsets.symmetric(vertical: 12),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(20),
@@ -608,7 +608,6 @@ class _EnhancedCheckAvailabilityCardState
                   ),
                 ),
               ),
-            ],
           ],
         ],
       ),


### PR DESCRIPTION
Instead of hiding the "Proceed to Room Selection" button when rooms are unavailable, this change disables it. This provides better user feedback by showing the button in a disabled state (greyed out) and preventing clicks.

The logic in `check_availability_card.dart` was updated to:
- Always show the button container if an availability check has been performed.
- Conditionally set the `onPressed` callback to `null` if `hasAvailability` is false.
- Change the button's background color to grey when disabled.