### PR TITLE
feat: Display terms and conditions on room and booking pages

### DIFF
--- a/tourism_app_new/lib/Screens/testing/Booking/booking_page.dart
+++ b/tourism_app_new/lib/Screens/testing/Booking/booking_page.dart
@@ -1,13 +1,17 @@
 // Screens/booking_screen.dart
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:tourism_app_new/models/booking_model.dart';
+import 'package:tourism_app_new/models/hotel_model.dart';
 import 'package:tourism_app_new/models/room_model.dart';
 import 'package:tourism_app_new/Services/Api%20Services/booking_api_service.dart';
 import 'package:tourism_app_new/Services/utils/user_shared_prefernce.dart';
 import 'package:tourism_app_new/constants/colors.dart';
 import 'package:tourism_app_new/models/user_model.dart';
+import 'package:tourism_app_new/widgets/terms_condition_widget.dart';
 
 class BookingScreen extends StatefulWidget {
+  final Hotel hotel;
   final Room room;
   final DateTime checkInDate;
   final String checkInTime;
@@ -18,6 +22,7 @@ class BookingScreen extends StatefulWidget {
 
   const BookingScreen({
     Key? key,
+    required this.hotel,
     required this.room,
     required this.checkInDate,
     required this.checkInTime,
@@ -787,21 +792,29 @@ class _BookingScreenState extends State<BookingScreen> {
               child: Column(
                 children: [
                   // Terms & Conditions
-                  Container(
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: const Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'Terms & Conditions',
-                          style: TextStyle(fontWeight: FontWeight.w500),
-                        ),
-                        Icon(Icons.chevron_right),
-                      ],
+                  GestureDetector(
+                    onTap: () {
+                      TermsConditionsWidget.showTermsAndConditions(
+                        context: context,
+                        terms: widget.hotel.terms,
+                      );
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            'Terms & Conditions',
+                            style: TextStyle(fontWeight: FontWeight.w500),
+                          ),
+                          Icon(Icons.chevron_right),
+                        ],
+                      ),
                     ),
                   ),
 
@@ -970,24 +983,31 @@ class _BookingScreenState extends State<BookingScreen> {
                               fontSize: 12,
                               color: Colors.grey.shade600,
                             ),
-                            children: const [
-                              TextSpan(text: 'I agree to the '),
+                            children: [
+                              const TextSpan(text: 'I agree to the '),
                               TextSpan(
                                 text: 'Terms & Conditions',
-                                style: TextStyle(
+                                style: const TextStyle(
                                   color: Colors.blue,
                                   decoration: TextDecoration.underline,
                                 ),
+                                recognizer: TapGestureRecognizer()
+                                  ..onTap = () {
+                                    TermsConditionsWidget.showTermsAndConditions(
+                                      context: context,
+                                      terms: widget.hotel.terms,
+                                    );
+                                  },
                               ),
-                              TextSpan(text: ' and '),
-                              TextSpan(
+                              const TextSpan(text: ' and '),
+                              const TextSpan(
                                 text: 'Privacy Policy',
                                 style: TextStyle(
                                   color: Colors.blue,
                                   decoration: TextDecoration.underline,
                                 ),
                               ),
-                              TextSpan(text: '.'),
+                              const TextSpan(text: '.'),
                             ],
                           ),
                         ),

--- a/tourism_app_new/lib/Screens/testing/Rooms/room_list.dart
+++ b/tourism_app_new/lib/Screens/testing/Rooms/room_list.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:tourism_app_new/constants/colors.dart';
 import 'package:tourism_app_new/models/availability_model.dart';
+import 'package:tourism_app_new/models/hotel_model.dart';
 import 'package:tourism_app_new/models/room_model.dart';
 import 'package:tourism_app_new/Screens/testing/Booking/booking_page.dart';
 import 'package:tourism_app_new/Services/Api%20Services/room_api_service.dart';
 import 'package:tourism_app_new/Services/Api%20Services/availablility_api_service.dart';
+import 'package:tourism_app_new/widgets/terms_condition_widget.dart';
 
 class RoomsListScreen extends StatefulWidget {
-  final int hotelId;
+  final Hotel hotel;
   final DateTime? checkInDate;
   final String? checkInTime;
   final DateTime? checkOutDate;
@@ -17,7 +19,7 @@ class RoomsListScreen extends StatefulWidget {
 
   const RoomsListScreen({
     Key? key,
-    required this.hotelId,
+    required this.hotel,
     this.checkInDate,
     this.checkInTime,
     this.checkOutDate,
@@ -93,7 +95,7 @@ class _RoomsListScreenState extends State<RoomsListScreen>
     _dataFuture.then((data) {
       final allRooms = data[0] as List<Room>;
       final availability = data[1] as RoomAvailability;
-      final availableRoomIds = availability.getRoomIdsForHotel(widget.hotelId);
+      final availableRoomIds = availability.getRoomIdsForHotel(widget.hotel.id);
 
       // Filter rooms properly
       final availableRooms =
@@ -117,7 +119,7 @@ class _RoomsListScreenState extends State<RoomsListScreen>
   }
 
   Future<List<dynamic>> _fetchRoomsAndAvailability() async {
-    final roomsFuture = RoomApiService.getRoomsByHotelId(widget.hotelId);
+    final roomsFuture = RoomApiService.getRoomsByHotelId(widget.hotel.id);
     final availabilityFuture = RoomAvailabilityService.searchAvailability(
       checkInDate: widget.checkInDate!,
       checkInTime: widget.checkInTime!,
@@ -181,6 +183,7 @@ class _RoomsListScreenState extends State<RoomsListScreen>
       MaterialPageRoute(
         builder:
             (context) => BookingScreen(
+              hotel: widget.hotel,
               room: _selectedRoom!,
               checkInDate: widget.checkInDate!,
               checkInTime: widget.checkInTime!,
@@ -404,7 +407,7 @@ class _RoomsListScreenState extends State<RoomsListScreen>
           final allRooms = snapshot.data![0] as List<Room>;
           final availability = snapshot.data![1] as RoomAvailability;
           final availableRoomIds = availability.getRoomIdsForHotel(
-            widget.hotelId,
+            widget.hotel.id,
           );
 
           final availableRooms =
@@ -1140,18 +1143,9 @@ class _RoomsListScreenState extends State<RoomsListScreen>
                         fontWeight: FontWeight.bold,
                       ),
                     ),
-                    GestureDetector(
-                      onTap: () {
-                        // Show terms and conditions
-                      },
-                      child: Text(
-                        "Terms & Conditions Apply",
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Colors.grey[600],
-                          decoration: TextDecoration.underline,
-                        ),
-                      ),
+                    TermsConditionsWidget.buildTermsButton(
+                      context: context,
+                      terms: widget.hotel.terms,
                     ),
                   ],
                 ),

--- a/tourism_app_new/lib/Screens/testing/hotel_detail.dart
+++ b/tourism_app_new/lib/Screens/testing/hotel_detail.dart
@@ -148,7 +148,7 @@ class _EnhancedHotelDetailsScreenState
       MaterialPageRoute(
         builder:
             (_) => RoomsListScreen(
-              hotelId: hotelId,
+              hotel: widget.hotel,
               checkInDate: searchParams.checkInDate,
               checkInTime: _formatTimeOfDay(searchParams.checkInTime),
               checkOutDate: checkOutDate,


### PR DESCRIPTION
This commit implements the user's request to show hotel-specific terms and conditions on the room list and booking pages.

- Updated the navigation flow to pass the full `Hotel` object from the hotel details page to the room list and booking pages, ensuring the terms are available where needed.
- Integrated the `TermsConditionsWidget` into the `RoomsListScreen` to display the terms in the bottom sheet.
- Added the `TermsConditionsWidget` to the `BookingScreen`, making the terms accessible from both the "Additional sections" list and the agreement checkbox.